### PR TITLE
Reorganize: one env per workspace — envs/ + persistent-states/ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-# Per-instance state dirs are runtime — keep only the README placeholder.
-# Default hooks/settings come from claude-sandbox-shared/, not from any
-# instance dir.
-claude-sandbox-persistent-state-*/*
-!claude-sandbox-persistent-state-*/README.md
+# Per-instance state dirs are runtime (persistent-states/<INSTANCE>/) — keep
+# only a README placeholder so the folder exists on a fresh clone. Default
+# hooks/settings come from claude-sandbox-shared/, not from any instance dir.
+persistent-states/*
+!persistent-states/README.md
 
 # Shared dir is also runtime, but track the default hooks scripts so a fresh
 # clone has working hooks on first launch.
@@ -54,7 +54,10 @@ context_reference/*
 
 SAVED_SNAPSHOTS
 
-# Per-instance env files are user-specific. Only the template is tracked.
+# Per-workspace env files (envs/env.<NAME>.sh) are user-specific. Only the
+# template is tracked. Legacy root-level env.*.sh kept ignored for old clones.
+envs/env.*.sh
+!envs/env.example.sh
 env.sh
 env.*.sh
 !env.example.sh
@@ -92,3 +95,6 @@ SESSION_ARCHIVE/INDEX.md
 # CLASSIFIED.md embeds session titles + prompt snippets too — same
 # privacy reason. It's your working attribution artifact, regenerable.
 SESSION_ARCHIVE/CLASSIFIED.md
+
+# Prewarmed HF model cache — downloaded by `make prewarm`, not source.
+docker/hf-cache/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Beyond the normal setup and build features, this sandbox has:
 - The [ponytail](https://github.com/DietrichGebert/ponytail) "lazy senior dev" plugin **vendored at v4.8.4** under `claude-sandbox-shared/.claude/plugins/marketplaces/ponytail/` — pushes the agent toward the smallest solution that works (YAGNI, stdlib first). Same vendoring model as caveman (no first-session network fetch), enabled by default, `[PONYTAIL]` chip in the statusline. Complements caveman: caveman shapes prose terseness, ponytail shapes code minimalism.
 - Optional read-only reference mounts: point `CLAUDE_SANDBOX_RO_MOUNTS` at host directories and they appear under `/read-only-reference/<name>` inside the container, enforced read-only at the mount layer (`EROFS`, un-remountable without `CAP_SYS_ADMIN`). See [Read-only reference mounts](#read-only-reference-mounts).
 - Optional `--shm-size` override via `CLAUDE_SANDBOX_SHM_SIZE` for workloads that need more than Docker's default 64 MB `/dev/shm` (Chromium/Playwright, PyTorch DataLoader). See [Shared memory](#shared-memory---shm-size).
-- An interactive launcher (`start_sandbox.sh`) that lets you pick instance, resume an existing Claude session, and choose a workdir from an fzf menu, instead of hand-sourcing `env.<INSTANCE>.sh` and running `run_claude_docker.sh` directly.
+- An interactive launcher (`start_sandbox.sh`) that lets you pick instance, resume an existing Claude session, and choose a workdir from an fzf menu, instead of hand-sourcing `envs/env.<INSTANCE>.sh` and running `run_claude_docker.sh` directly.
 - A composite statusline showing model · effort, the active backend (`[CLAUDE.AI]` / `[VERTEX]`), live headroom savings (`[HR 2.0M]`, measured), and per-session caveman savings (`[CAVEMAN ⛏ 2.1M]`, estimated) plus plugin chips. See [Statusline badges](#statusline-badges).
 
 I've tried to include everything I need for my typical work.
@@ -45,16 +45,16 @@ Runs on **Linux** and **macOS** (Apple Silicon or Intel). User-facing scripts (`
 cd docker && make && cd ..
 
 # 3. Launch the default "main" shared-mode instance.
-#    env.example.sh defaults to in-repo workspace/ + context_reference/.
-source env.example.sh
+#    envs/env.example.sh defaults to in-repo workspace/ + context_reference/.
+source envs/env.example.sh
 ./run_claude_docker.sh
 ```
 
-First launch in any sandbox prompts `/login` inside the container. The resulting OAuth token persists into that sandbox's state dir (`claude-sandbox-shared/.claude/.credentials.json` in shared mode, `claude-sandbox-persistent-state-<INSTANCE>/.claude/.credentials.json` in per-instance mode), so subsequent launches of the same sandbox skip the login. No host-side Claude Code install is required, and credentials are not shared with the host's `~/.claude/`.
+First launch in any sandbox prompts `/login` inside the container. The resulting OAuth token persists into that sandbox's state dir (`claude-sandbox-shared/.claude/.credentials.json` in shared mode, `persistent-states/<INSTANCE>/.claude/.credentials.json` in per-instance mode), so subsequent launches of the same sandbox skip the login. No host-side Claude Code install is required, and credentials are not shared with the host's `~/.claude/`.
 
 ### Interactive launcher (alternative to step 4)
 
-`start_sandbox.sh` opens an fzf menu: pick instance, optionally resume an existing Claude session, pick a workdir, launch. It seeds workdir candidates from any `env.*.sh` plus every workdir you've previously picked (master registry at `workdirs.txt`). Sessions are annotated with their host workdir in the picker so you can tell two `main` sessions apart by what they were operating on.
+`start_sandbox.sh` opens an fzf menu: pick instance, optionally resume an existing Claude session, pick a workdir, launch. It seeds workdir candidates from any `envs/env.*.sh` plus every workdir you've previously picked (master registry at `workdirs.txt`). Sessions are annotated with their host workdir in the picker so you can tell two `main` sessions apart by what they were operating on.
 
 ```bash
 ./start_sandbox.sh
@@ -65,12 +65,12 @@ First launch in any sandbox prompts `/login` inside the container. The resulting
 For a second concurrent instance, copy the template and change the instance name:
 
 ```bash
-cp env.example.sh env.B.sh
-$EDITOR env.B.sh   # set CLAUDE_SANDBOX_INSTANCE=B (and PROJECTS_DIR if different)
-source env.B.sh && ./run_claude_docker.sh
+cp envs/env.example.sh envs/env.B.sh
+$EDITOR envs/env.B.sh   # set CLAUDE_SANDBOX_INSTANCE=B (and PROJECTS_DIR if different)
+source envs/env.B.sh && ./run_claude_docker.sh
 ```
 
-`env.*.sh` (other than `env.example.sh`) is gitignored — your per-instance files won't accidentally land in commits.
+`envs/env.*.sh` (other than `envs/env.example.sh`) is gitignored — your per-instance files won't accidentally land in commits.
 
 For details on per-instance vs shared layouts and parallel launches, see [Mounts](#mounts).
 
@@ -130,7 +130,7 @@ Approximate image size: ~3 GB.
 - **No mail relay by default.** Linux's `setup_host.sh` configures host postfix with mynetworks so the in-container hook can send via SMTP. macOS has no stock outbound-MTA path; `setup_host_macos.sh` prints instructions for configuring `/etc/postfix/main.cf` with SMTP-AUTH against Gmail/SES/SendGrid, but does not automate it. Skip if you don't need email notifications.
 - **Email notifications remain untested and may not work even after configuration.**
 
-- No host-side Claude Code install required. Each sandbox prompts `/login` on its own first launch and stores the resulting OAuth token inside its own state dir (`claude-sandbox-shared/.claude/.credentials.json` in shared mode, `claude-sandbox-persistent-state-<INSTANCE>/.claude/.credentials.json` in per-instance mode). The host's `~/.claude/` is NOT mounted into the container.
+- No host-side Claude Code install required. Each sandbox prompts `/login` on its own first launch and stores the resulting OAuth token inside its own state dir (`claude-sandbox-shared/.claude/.credentials.json` in shared mode, `persistent-states/<INSTANCE>/.claude/.credentials.json` in per-instance mode). The host's `~/.claude/` is NOT mounted into the container.
 
 ## Build
 
@@ -174,7 +174,7 @@ How it works: when `HEADROOM=1`, `start_script.sh` launches `headroom proxy` on 
 
 Trust model: the proxy reads every byte of every request — that's how compression works. It runs entirely inside the same container as `claude`, so it sees the same OAuth token Claude already has and no wider trust boundary is opened. Code is Apache-2.0; pin the version in `Dockerfile`. If you don't want a third-party dep in the request path, leave `HEADROOM` unset and traffic goes direct.
 
-Per-instance default: add `export HEADROOM=1` to the matching `env.<INSTANCE>.sh` to make it sticky for that sandbox.
+Per-instance default: add `export HEADROOM=1` to the matching `envs/env.<INSTANCE>.sh` to make it sticky for that sandbox.
 
 ## Statusline badges
 
@@ -276,7 +276,7 @@ FISS_MCP_ALLOW_WRITES=1 ./run_claude_docker.sh    # on, WRITE MODE (loud banner)
 
 **Lifecycle**: trap on `EXIT INT TERM` kills the host fastmcp process. If the launcher is `kill -9`'d, the orphan can be reaped with `pkill -f run-server.py`. The MCP log lives at `${SANDBOX_HOME}/.claude/host_fiss_mcp.log`.
 
-Per-instance default: set `FISS_MCP` / `FISS_MCP_ALLOW_WRITES` / `FISS_MCP_PORT` in `env.<INSTANCE>.sh`.
+Per-instance default: set `FISS_MCP` / `FISS_MCP_ALLOW_WRITES` / `FISS_MCP_PORT` in `envs/env.<INSTANCE>.sh`.
 
 ## Vertex AI mode (Google Cloud auth)
 
@@ -306,7 +306,7 @@ source SET_VERTEX_MODE.sh
 
 `SET_VERTEX_MODE.sh` is gitignored — your real project id won't accidentally land in a commit. To go back to default Anthropic-API (subscription) mode, `source UNSET_VERTEX_MODE.sh` (or open a fresh shell).
 
-**Toggle**: per-launch, not mid-session. claude reads env at startup. Different `env.<INSTANCE>.sh` files can pin different modes (one sandbox always Vertex, another always subscription).
+**Toggle**: per-launch, not mid-session. claude reads env at startup. Different `envs/env.<INSTANCE>.sh` files can pin different modes (one sandbox always Vertex, another always subscription).
 
 | HEADROOM | USE_VERTEX | Flow |
 |---|---|---|
@@ -341,7 +341,7 @@ When HEADROOM=0, `start_script.sh` instead sets `ANTHROPIC_BASE_URL=$ANTHROPIC_T
 
 **fiss-mcp and Vertex are orthogonal** — you can run both simultaneously (separate processes, separate port ranges, separate trap cleanups) or either alone.
 
-Per-instance default: add `source SET_VERTEX_MODE.sh` at the top of `env.<INSTANCE>.sh` if you want a specific sandbox to always run in Vertex mode.
+Per-instance default: add `source SET_VERTEX_MODE.sh` at the top of `envs/env.<INSTANCE>.sh` if you want a specific sandbox to always run in Vertex mode.
 
 ## Mounts
 
@@ -350,7 +350,7 @@ Two layout modes, picked per launch by `CLAUDE_SANDBOX_USE_SHARED`:
 - **Per-instance (`=0` or unset)** — full Claude state lives in `$SANDBOX_HOME/.claude` for this one instance. Instances are fully independent. No shared dir touched.
 - **Shared (`=1`)** — settings/skills/plugins/hooks/plans/tasks/sessions come from `$SHARED_HOME` (one copy across all shared-mode instances). `.claude.json` plus write-hot dirs (cache, file-history, backups, shell-snapshots, session-env, projects, history.jsonl) stay in `$SANDBOX_HOME` and bind-mount on top of the shared `.claude`. `.claude.json` and `projects/` are per-instance because they're rewritten on every change and hold per-project allowedTools/mcpServers/history/transcripts that would race if shared.
 
-The example envs (`env.example.sh`, `env.B.sh`, `env.WHB.sh`, `env.GATK.sh`, `env.main.sh`) all set `CLAUDE_SANDBOX_USE_SHARED=1` — shared is the de-facto default on this checkout. The code-level fallback (when neither set nor sourced) is per-instance.
+The example envs (`envs/env.example.sh`, `envs/env.B.sh`, `envs/env.WHB.sh`, `envs/env.GATK.sh`, `envs/env.main.sh`) all set `CLAUDE_SANDBOX_USE_SHARED=1` — shared is the de-facto default on this checkout. The code-level fallback (when neither set nor sourced) is per-instance.
 
 ### Per-instance mode (default)
 
@@ -381,13 +381,13 @@ The host's `~/.claude/` is NOT mounted. The OAuth token from `/login` lands at `
 
 The OAuth token from `/login` lands inside the shared `.claude/` (at `$SHARED_HOME/.claude/.credentials.json`) and is therefore shared across every shared-mode sandbox on this host — log in once, every shared-mode instance reuses the token. The host's `~/.claude/` is NOT mounted.
 
-`$SHARED_HOME` defaults to `claude-sandbox-shared/` next to `run_claude_docker.sh` (override: `CLAUDE_SANDBOX_SHARED`). `$SANDBOX_HOME` defaults to `claude-sandbox-persistent-state-${CLAUDE_SANDBOX_INSTANCE}/` (override: `CLAUDE_SANDBOX_HOME`). Both must be absolute paths.
+`$SHARED_HOME` defaults to `claude-sandbox-shared/` next to `run_claude_docker.sh` (override: `CLAUDE_SANDBOX_SHARED`). `$SANDBOX_HOME` defaults to `persistent-states/${CLAUDE_SANDBOX_INSTANCE}/` (override: `CLAUDE_SANDBOX_HOME`). Both must be absolute paths.
 
 Nothing else on the host is visible to the container.
 
 ### Adopting shared mode safely (no risk to existing instances)
 
-Opt a sandbox into shared mode by adding `export CLAUDE_SANDBOX_USE_SHARED=1` to its `env.<INSTANCE>.sh` (the bundled `env.*.sh` files already do this). First launch on a fresh clone uses the tracked `claude-sandbox-shared/.claude/` (CLAUDE.md, settings.json, hooks, skills, **vendored caveman plugin source**, caveman defaults) directly; subsequent launches reuse it. Switch back to per-instance any time by removing that line — `run_claude_docker.sh` will seed a copy of the tracked settings + hooks into the per-instance dir on first launch (`seed_settings` / `seed_hooks`).
+Opt a sandbox into shared mode by adding `export CLAUDE_SANDBOX_USE_SHARED=1` to its `envs/env.<INSTANCE>.sh` (the bundled `envs/env.*.sh` files already do this). First launch on a fresh clone uses the tracked `claude-sandbox-shared/.claude/` (CLAUDE.md, settings.json, hooks, skills, **vendored caveman plugin source**, caveman defaults) directly; subsequent launches reuse it. Switch back to per-instance any time by removing that line — `run_claude_docker.sh` will seed a copy of the tracked settings + hooks into the per-instance dir on first launch (`seed_settings` / `seed_hooks`).
 
 ### Concurrency caveats (shared mode)
 
@@ -399,7 +399,7 @@ Hot dirs are per-instance — no race. Shared items are write-rare in practice, 
 
 ## Read-only reference mounts
 
-Optional caller-supplied read-only bind mounts for reference datasets, shared corpora, system config — anything the agent should be able to read but never mutate. Set `CLAUDE_SANDBOX_RO_MOUNTS` in your `env.<INSTANCE>.sh` to a **space-separated list of host directories** (no container path — the launcher picks one):
+Optional caller-supplied read-only bind mounts for reference datasets, shared corpora, system config — anything the agent should be able to read but never mutate. Set `CLAUDE_SANDBOX_RO_MOUNTS` in your `envs/env.<INSTANCE>.sh` to a **space-separated list of host directories** (no container path — the launcher picks one):
 
 ```bash
 export CLAUDE_SANDBOX_RO_MOUNTS="/data/reference /srv/corpus /etc/shared-config"
@@ -425,7 +425,7 @@ The interactive launcher (`start_sandbox.sh`) shows a one-line `RO mounts` summa
 
 ## Shared memory (`--shm-size`)
 
-Docker's default `/dev/shm` is 64 MB, which is too small for Chromium/Playwright, PyTorch DataLoader workers, and other multi-process shared-memory consumers — they fail with `No space left on device` on `/dev/shm`. Set `CLAUDE_SANDBOX_SHM_SIZE` in your `env.<INSTANCE>.sh` to raise it:
+Docker's default `/dev/shm` is 64 MB, which is too small for Chromium/Playwright, PyTorch DataLoader workers, and other multi-process shared-memory consumers — they fail with `No space left on device` on `/dev/shm`. Set `CLAUDE_SANDBOX_SHM_SIZE` in your `envs/env.<INSTANCE>.sh` to raise it:
 
 ```bash
 export CLAUDE_SANDBOX_SHM_SIZE=2g   # Docker size syntax: 512m, 2g, 4g, …
@@ -435,7 +435,7 @@ The launcher passes it through as `docker run --shm-size`. Unset → Docker's 64
 
 ## Email notifications
 
-A hook (`notify-if-long.sh`) emails you when a prompt takes longer than a threshold (default 120 s) and when a session ends. Configure in your `env.<INSTANCE>.sh`:
+A hook (`notify-if-long.sh`) emails you when a prompt takes longer than a threshold (default 120 s) and when a session ends. Configure in your `envs/env.<INSTANCE>.sh`:
 
 ```bash
 export CLAUDE_NOTIFY_EMAIL=you@example.com          # recipient; unset/empty disables
@@ -465,12 +465,12 @@ This sandbox restricts **filesystem access only**. Network access from inside th
 
 ## Adapting paths for your machine
 
-Paths are driven by environment variables — nothing is hardcoded in `run_claude_docker.sh`. Set these in your `env.<INSTANCE>.sh` (start from `env.example.sh`):
+Paths are driven by environment variables — nothing is hardcoded in `run_claude_docker.sh`. Set these in your `envs/env.<INSTANCE>.sh` (start from `envs/env.example.sh`):
 
 - `CLAUDE_SANDBOX_PROJECTS_DIR` — host dir mounted at `/workspace` (required).
 - `CLAUDE_SANDBOX_CONTEXT_DIR` — host dir mounted at `/context` (required).
 - `CLAUDE_SANDBOX_INSTANCE` — unique instance name (required; suffixes container, DinD volume, state dir).
-- `CLAUDE_SANDBOX_HOME` — override the per-instance state dir (default: `claude-sandbox-persistent-state-<INSTANCE>/` alongside the launcher).
+- `CLAUDE_SANDBOX_HOME` — override the per-instance state dir (default: `persistent-states/<INSTANCE>/` alongside the launcher).
 - `CLAUDE_SANDBOX_SHARED` — override the shared dir in shared mode (default: `claude-sandbox-shared/`).
 
 Per-instance overrides also cover `HEADROOM`, `HEADROOM_PORT`, `FISS_MCP`, `FISS_MCP_ALLOW_WRITES`, `FISS_MCP_PORT`, `CODEGRAPH` (set `=0` to skip CodeGraph MCP registration in that sandbox), `CLAUDE_SANDBOX_USE_SHARED`, `CLAUDE_SANDBOX_RO_MOUNTS` (space-separated host directories — no container path; each shows up at `/read-only-reference/<basename>` inside the container, with parent-dir prefixes underscored on collision; host paths must exist or the launcher refuses), and the Vertex-mode launcher signals (`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`, `ANTHROPIC_MODEL`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `VERTEX_PROXY_PORT`) — set whichever you want sticky for that sandbox.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ source envs/env.example.sh
 
 First launch in any sandbox prompts `/login` inside the container. The resulting OAuth token persists into that sandbox's state dir (`claude-sandbox-shared/.claude/.credentials.json` in shared mode, `persistent-states/<INSTANCE>/.claude/.credentials.json` in per-instance mode), so subsequent launches of the same sandbox skip the login. No host-side Claude Code install is required, and credentials are not shared with the host's `~/.claude/`.
 
-### Interactive launcher (alternative to step 4)
+### Interactive launcher (alternative to step 3)
 
 `start_sandbox.sh` opens an fzf menu: pick instance, optionally resume an existing Claude session, pick a workdir, launch. It seeds workdir candidates from any `envs/env.*.sh` plus every workdir you've previously picked (master registry at `workdirs.txt`). Sessions are annotated with their host workdir in the picker so you can tell two `main` sessions apart by what they were operating on.
 

--- a/SESSION_ARCHIVE/README.md
+++ b/SESSION_ARCHIVE/README.md
@@ -23,7 +23,7 @@ SESSION_ARCHIVE/
 ```
 
 `<source>` is an instance name (`B`, `GATK`, `WHB`, `main`, …) from a
-per-instance state dir `claude-sandbox-persistent-state-<INSTANCE>`, or
+per-instance state dir `persistent-states/<INSTANCE>`, or
 `shared` from `claude-sandbox-shared` — the one state dir all
 `CLAUDE_SANDBOX_USE_SHARED=1` instances write into. Shared-mode
 transcripts can't be attributed back to a single instance: every shared
@@ -46,7 +46,7 @@ pile of sessions apart into projects.
 bash SESSION_ARCHIVE/archive_sessions.sh
 ```
 
-Auto-discovers every `claude-sandbox-persistent-state-*` dir plus
+Auto-discovers every `persistent-states/*` dir plus
 `claude-sandbox-shared`, copies each source's `projects/` transcripts and
 `history.jsonl` into `SESSION_ARCHIVE/<source>/`, prints a per-source
 count.

--- a/SESSION_ARCHIVE/archive_sessions.sh
+++ b/SESSION_ARCHIVE/archive_sessions.sh
@@ -3,9 +3,8 @@
 # instance's live state dir into SESSION_ARCHIVE/, on demand.
 #
 # Sources scanned (relative to the repo root):
-#   claude-sandbox-persistent-state-<INSTANCE>/.claude/  — per-instance state
-#   claude-sandbox-shared/.claude/                       — shared-mode state
-#                                                          (USE_SHARED=1)
+#   persistent-states/<INSTANCE>/.claude/  — per-instance state
+#   claude-sandbox-shared/.claude/         — shared-mode state (USE_SHARED=1)
 #
 # For each source we copy:
 #   .claude/projects/    session transcripts (<uuid>.jsonl) + their sidecar
@@ -58,10 +57,10 @@ archive_one() {
 
 echo "Archiving session history into ${ARCHIVE_DIR#$REPO_ROOT/}/ ..."
 
-# Per-instance state dirs.
-for d in "$REPO_ROOT"/claude-sandbox-persistent-state-*; do
+# Per-instance state dirs (persistent-states/<INSTANCE>/).
+for d in "$REPO_ROOT"/persistent-states/*; do
     [ -d "$d" ] || continue
-    archive_one "$d/.claude" "${d##*-state-}"
+    archive_one "$d/.claude" "$(basename "$d")"
 done
 
 # Shared-mode state (one dir, all shared instances write here).

--- a/claude-sandbox-persistent-state-main/README.md
+++ b/claude-sandbox-persistent-state-main/README.md
@@ -1,2 +1,0 @@
-# claude-sandbox-persistent-state
-Default folder in which to keep the persistent-state between run instances.

--- a/claude-sandbox-shared/.claude/hooks/notify-if-long.sh
+++ b/claude-sandbox-shared/.claude/hooks/notify-if-long.sh
@@ -22,7 +22,7 @@ PROMPT_FILE="${HOME}/claude_task_prompt_$(basename $PWD)"
 HOST_IP=$(ip route | awk '/default/ {print $3}')
 SMTP_PORT=25
 
-# Notification config — set via env in env.<INSTANCE>.sh, forwarded by
+# Notification config — set via env in envs/env.<INSTANCE>.sh, forwarded by
 # run_claude_docker.sh into the container. Hook is a no-op if
 # CLAUDE_NOTIFY_EMAIL is unset/empty.
 CLAUDE_FROM_ADDRESS="${CLAUDE_NOTIFY_FROM:-claude-sandbox}"

--- a/claude-sandbox-shared/.claude/hooks/notify-if-rate-limited.sh
+++ b/claude-sandbox-shared/.claude/hooks/notify-if-rate-limited.sh
@@ -17,7 +17,7 @@ PROMPT_FILE="${HOME}/claude_task_prompt_$(basename $PWD)"
 HOST_IP=$(ip route | awk '/default/ {print $3}')
 SMTP_PORT=25
 
-# Notification config — set via env in env.<INSTANCE>.sh, forwarded by
+# Notification config — set via env in envs/env.<INSTANCE>.sh, forwarded by
 # run_claude_docker.sh into the container. Hook is a no-op if
 # CLAUDE_NOTIFY_EMAIL is unset/empty.
 CLAUDE_FROM_ADDRESS="${CLAUDE_NOTIFY_FROM:-claude-sandbox}"

--- a/envs/env.example.sh
+++ b/envs/env.example.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 # env.example.sh — defaults work on a fresh clone with no edits.
+# Lives in envs/ alongside one env.<NAME>.sh per workspace.
 #
 # Source directly for the "main" shared-mode instance:
-#   source env.example.sh && ./run_claude_docker.sh
+#   source envs/env.example.sh && ./run_claude_docker.sh
 #
-# For a second instance, copy and tweak:
-#   cp env.example.sh env.<NAME>.sh
-#   $EDITOR env.<NAME>.sh   # change CLAUDE_SANDBOX_INSTANCE, optionally paths
-#   source env.<NAME>.sh && ./run_claude_docker.sh
+# For a new workspace, copy and tweak:
+#   cp envs/env.example.sh envs/env.<NAME>.sh
+#   $EDITOR envs/env.<NAME>.sh   # change CLAUDE_SANDBOX_INSTANCE, optionally paths
+#   source envs/env.<NAME>.sh && ./run_claude_docker.sh
+#
+# Each env gets its own persistent state at persistent-states/<INSTANCE>/.
 
-# Resolve repo root regardless of where this file is sourced from.
-__ENV_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve repo root. This file lives in envs/, so repo root is the PARENT
+# of its own directory — hence the /.. below. All ${__ENV_SCRIPT_DIR}
+# defaults (context_reference, workspace) resolve against the repo root.
+__ENV_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Shared-state layout: settings, skills, plugins, hooks, memory, sessions
 # come from claude-sandbox-shared/. Set to 0 for fully isolated per-instance

--- a/persistent-states/README.md
+++ b/persistent-states/README.md
@@ -1,0 +1,15 @@
+# persistent-states/
+
+Per-instance persistent sandbox state, one subdirectory per workspace:
+`persistent-states/<INSTANCE>/`. Each maps 1:1 to an env script
+(`envs/env.<INSTANCE>.sh`, whose `CLAUDE_SANDBOX_INSTANCE=<INSTANCE>`).
+
+A subdir holds that instance's `.claude/` (cache, file-history, backups,
+shell-snapshots, session-env, projects/, history.jsonl) and its
+`.claude.json`. It is created and seeded automatically by
+`run_claude_docker.sh` on first launch — you never make one by hand.
+
+Everything under here is runtime state and is gitignored (only this
+README is tracked). Wiping a subdir resets that instance to a clean
+login on next launch. Session transcripts can be snapshotted first with
+`SESSION_ARCHIVE/archive_sessions.sh`.

--- a/run_claude_docker.sh
+++ b/run_claude_docker.sh
@@ -13,14 +13,14 @@ DOCKER_IMAGE_VERSION=0.0.1
 if [[ -z "${CLAUDE_SANDBOX_PROJECTS_DIR:-}" ]] || [[ ! -d "${CLAUDE_SANDBOX_PROJECTS_DIR}" ]]; then
     echo "CRITICAL ERROR: CLAUDE_SANDBOX_PROJECTS_DIR is not set, is empty, or does not exist." >&2
     echo "                You must set this env var before starting the docker image." >&2
-    echo "                Try: source env.example.sh   (or your env.<INSTANCE>.sh)" >&2
+    echo "                Try: source envs/env.example.sh  (or your envs/env.<INSTANCE>.sh)" >&2
     exit 1
 fi
 
 if [[ -z "${CLAUDE_SANDBOX_CONTEXT_DIR:-}" ]] || [[ ! -d "${CLAUDE_SANDBOX_CONTEXT_DIR}" ]]; then
     echo "CRITICAL ERROR: CLAUDE_SANDBOX_CONTEXT_DIR is not set, is empty, or does not exist." >&2
     echo "                You must set this env var before starting the docker image." >&2
-    echo "                Try: source env.example.sh   (or your env.<INSTANCE>.sh)" >&2
+    echo "                Try: source envs/env.example.sh  (or your envs/env.<INSTANCE>.sh)" >&2
     exit 1
 fi
 
@@ -28,7 +28,7 @@ if [[ -z "${CLAUDE_SANDBOX_INSTANCE:-}" ]]; then
     echo "CRITICAL ERROR: CLAUDE_SANDBOX_INSTANCE is not set, does not exist, or is empty." >&2
     echo "                Each sandbox needs a unique instance ID so concurrent" >&2
     echo "                inner dockerds don't share /var/lib/docker." >&2
-    echo "                Try: source env.example.sh   (or your env.<INSTANCE>.sh)" >&2
+    echo "                Try: source envs/env.example.sh  (or your envs/env.<INSTANCE>.sh)" >&2
     exit 1
 fi
 
@@ -57,7 +57,7 @@ CONTAINER_NAME="claude-sandbox-${CLAUDE_SANDBOX_INSTANCE}"
 #
 # Existing per-instance dirs are untouched when USE_SHARED=0, so old instances
 # keep working exactly as before. Opt new instances into shared mode by
-# exporting CLAUDE_SANDBOX_USE_SHARED=1 in their env.<INSTANCE>.sh.
+# exporting CLAUDE_SANDBOX_USE_SHARED=1 in their envs/env.<INSTANCE>.sh.
 USE_SHARED="${CLAUDE_SANDBOX_USE_SHARED:-0}"
 
 # Resolve the script's actual location, following symlinks, so SCRIPT_DIR
@@ -116,7 +116,9 @@ resolve_host_bind_ip() {
     fi
     printf '%s' "$ip"
 }
-PERSISTENT_STATE_DIR="${SCRIPT_DIR}/claude-sandbox-persistent-state${INSTANCE_SUFFIX}"
+# Per-instance persistent state lives under persistent-states/<INSTANCE>/.
+# One env (envs/env.<INSTANCE>.sh) -> one instance -> one state dir here.
+PERSISTENT_STATE_DIR="${SCRIPT_DIR}/persistent-states/${CLAUDE_SANDBOX_INSTANCE}"
 SHARED_STATE_DIR="${SCRIPT_DIR}/claude-sandbox-shared"
 SANDBOX_HOME="${CLAUDE_SANDBOX_HOME:-$PERSISTENT_STATE_DIR}"
 SHARED_HOME="${CLAUDE_SANDBOX_SHARED:-$SHARED_STATE_DIR}"
@@ -330,7 +332,7 @@ MOUNTS+=(
 # to launch otherwise so Docker doesn't auto-create it as a directory
 # (same trap the `check_not_directory` guard above protects against).
 #
-# Example env.<INSTANCE>.sh:
+# Example envs/env.<INSTANCE>.sh:
 #   export CLAUDE_SANDBOX_RO_MOUNTS="/data/reference /srv/corpus /etc/shared-config"
 RO_MOUNTS_RAW="${CLAUDE_SANDBOX_RO_MOUNTS:-}"
 if [[ -n "$RO_MOUNTS_RAW" ]]; then

--- a/scripts/sandbox_lib.sh
+++ b/scripts/sandbox_lib.sh
@@ -163,7 +163,7 @@ elif first_user:
 PY
 }
 
-# Read env.<INSTANCE>.sh flag state without leaking vars into caller.
+# Read envs/env.<INSTANCE>.sh flag state without leaking vars into caller.
 # Prints five pipe-separated fields:
 #   <projects_dir>|<headroom>|<fiss_writes>|<vertex>|<ro_mounts>
 # Each flag is "1" if enabled, "0" if not. projects_dir is the resolved value.
@@ -253,16 +253,16 @@ sb_write_session_workdir() {
     printf '%s\n' "$workdir" > "$sidecar"
 }
 
-# Parse all env.*.sh files for `export CLAUDE_SANDBOX_PROJECTS_DIR=...` lines
-# (active OR commented) and emit the resolved paths, one per line.
+# Parse all envs/env.*.sh files for `export CLAUDE_SANDBOX_PROJECTS_DIR=...`
+# lines (active OR commented) and emit the resolved paths, one per line.
 #
-# Substitutes ${__ENV_SCRIPT_DIR} → the script dir argument so paths under
-# the repo expand properly. Skips env.example.sh.
+# Substitutes ${__ENV_SCRIPT_DIR} → the script dir argument (repo root) so
+# paths under the repo expand properly. Skips env.example.sh.
 sb_collect_env_workdirs() {
     local script_dir=$1
     shopt -s nullglob
     local f
-    for f in "$script_dir"/env.*.sh; do
+    for f in "$script_dir"/envs/env.*.sh; do
         local base name
         base=$(basename "$f" .sh)
         name=${base#env.}

--- a/scripts/setup_host_macos.sh
+++ b/scripts/setup_host_macos.sh
@@ -193,6 +193,6 @@ echo
 echo "Next steps:"
 echo "  1. Make sure Docker Desktop / OrbStack is running."
 echo "  2. cd docker && make             # build the sandbox image"
-echo "  3. source env.example.sh"
+echo "  3. source envs/env.example.sh"
 echo "  4. ./run_claude_docker.sh        # /login prompts inside the container"
 echo

--- a/start_sandbox.sh
+++ b/start_sandbox.sh
@@ -8,7 +8,7 @@
 #   3. Combined session+flags picker — recent sessions (mtime-desc) with
 #      "▶ NEW SESSION" at the bottom; Headroom / Vertex / FISS-writes flags
 #      shown in the right preview pane and toggled live via Alt-H / Alt-V /
-#      Alt-F. Flag changes persist back to env.<INSTANCE>.sh inside a managed
+#      Alt-F. Flag changes persist back to envs/env.<INSTANCE>.sh inside a managed
 #      block (idempotent) when the user finally launches.
 #   4. Sources the (possibly patched) env file and execs
 #      ./run_claude_docker.sh --dangerously-skip-permissions [--resume <uuid>].
@@ -18,7 +18,7 @@
 # per-process tempdir. ESC-ing backward through the flow re-uses those caches
 # instead of re-forking docker / python, so navigation is instant.
 #
-# Managed block convention: env.<INSTANCE>.sh may contain a block bracketed by
+# Managed block convention: envs/env.<INSTANCE>.sh may contain a block bracketed by
 # the markers below. start_sandbox.sh regenerates that block from current
 # toggle state; everything outside the markers is preserved verbatim.
 #
@@ -48,7 +48,7 @@ MARK_BEGIN="# vvv start_sandbox managed block — regenerated, do not edit vvv"
 MARK_END="# ^^^ start_sandbox managed block ^^^"
 
 # Master workdir registry. Plain text, one absolute host path per line. Seeded
-# from every env.<area>.sh `export CLAUDE_SANDBOX_PROJECTS_DIR=...` line (both
+# from every envs/env.<area>.sh `export CLAUDE_SANDBOX_PROJECTS_DIR=...` line (both
 # active and commented out) on first run; thereafter every chosen workdir is
 # unioned in. This is the "master coordinating location" — the list of paths
 # this host knows it can mount at /workspace.
@@ -185,7 +185,7 @@ hrule() { local w=$1 ch=${2:-─}; printf '%*s' "$w" '' | tr ' ' "$ch"; }
 
 # --- workdir registry --------------------------------------------------------
 #
-# Maintain $WORKDIRS_FILE as union(existing file, env.<area>.sh parsed paths).
+# Maintain $WORKDIRS_FILE as union(existing file, envs/env.<area>.sh parsed paths).
 # Sorted, unique. Idempotent: running twice with no env changes produces no
 # diff. Writes only if content changed (avoids meaningless mtime bumps).
 sync_workdirs_registry() {
@@ -218,7 +218,7 @@ register_workdir() {
 # --- area discovery ----------------------------------------------------------
 
 shopt -s nullglob
-ENV_FILES=("$SCRIPT_DIR"/env.*.sh)
+ENV_FILES=("$SCRIPT_DIR"/envs/env.*.sh)
 shopt -u nullglob
 
 declare -a AREAS=()
@@ -230,8 +230,8 @@ for f in "${ENV_FILES[@]}"; do
 done
 
 [[ ${#AREAS[@]} -gt 0 ]] || {
-    echo "No env.<NAME>.sh files found in ${SCRIPT_DIR}." >&2
-    echo "Copy env.example.sh to env.<NAME>.sh first." >&2
+    echo "No envs/env.<NAME>.sh files found in ${SCRIPT_DIR}/envs." >&2
+    echo "Copy envs/env.example.sh to envs/env.<NAME>.sh first." >&2
     exit 1
 }
 
@@ -267,8 +267,8 @@ build_one_area() {
     local envfile state_dir flags projects_dir hr fw vx ro_mounts badge
     local latest mt age sname desc uuid area_label status
 
-    envfile="$SCRIPT_DIR/env.${area}.sh"
-    state_dir="$SCRIPT_DIR/claude-sandbox-persistent-state-${area}"
+    envfile="$SCRIPT_DIR/envs/env.${area}.sh"
+    state_dir="$SCRIPT_DIR/persistent-states/${area}"
     flags=$(sb_read_env_flags "$envfile")
     IFS='|' read -r projects_dir hr fw vx ro_mounts <<<"$flags"
     badge=$(flag_badge "$hr" "$vx" "$fw")
@@ -317,7 +317,7 @@ build_one_area() {
 
     {
         printf '╭─ Sandbox %s\n' "$area"
-        printf '│  Env file   env.%s.sh\n' "$area"
+        printf '│  Env file   envs/env.%s.sh\n' "$area"
         printf '│  Workdir    %s\n' "${projects_dir:-?}"
         printf '│  State dir  %s\n' "$state_dir"
         printf '│  Status     %s\n' "$status"
@@ -365,7 +365,7 @@ build_session_cache() {
     local wdirs_file="$PREVIEW_CACHE_DIR/sessions.${area}.workdirs"
     : > "$wdirs_file"
 
-    local state_dir="$SCRIPT_DIR/claude-sandbox-persistent-state-${area}/.claude/projects"
+    local state_dir="$SCRIPT_DIR/persistent-states/${area}/.claude/projects"
     if [ -d "$state_dir" ]; then
         local mt f uuid age name desc_full short workdir wd_short
         while IFS=$'\t' read -r mt f; do
@@ -638,7 +638,7 @@ persist_toggles() {
     } > "$ENV_FILE"
     rm -f "$TMP"
 
-    echo "Updated env.${CHOSEN_AREA}.sh: Headroom=$HR Vertex=$VX FISS_writes=$FW"
+    echo "Updated envs/env.${CHOSEN_AREA}.sh: Headroom=$HR Vertex=$VX FISS_writes=$FW"
     # Sync baseline so a later round-trip through this menu doesn't re-write
     # the block when nothing further changed.
     INITIAL_HR=$HR; INITIAL_VX=$VX; INITIAL_FW=$FW
@@ -686,7 +686,7 @@ session_header_labels(){ session_row "WORKDIR" "UUID" "LAST" "SUMMARY"; }
 # Returns 0 (sets CHOSEN_SESSION + HR/VX/FW + ENV_FILE + INITIAL_*),
 # 10 (ESC → back to area picker), 130 (Ctrl-C).
 pick_session() {
-    ENV_FILE="$SCRIPT_DIR/env.${CHOSEN_AREA}.sh"
+    ENV_FILE="$SCRIPT_DIR/envs/env.${CHOSEN_AREA}.sh"
     local toggle_file="$PREVIEW_CACHE_DIR/toggles.${CHOSEN_AREA}"
     local sess_rows="$PREVIEW_CACHE_DIR/sessions.${CHOSEN_AREA}.rows"
     local sess_uuids="$PREVIEW_CACHE_DIR/sessions.${CHOSEN_AREA}.uuids"
@@ -920,7 +920,7 @@ export CLAUDE_SANDBOX_PROJECTS_DIR="$CHOSEN_WORKDIR"
 # already there (came from the picker list), this is a no-op write.
 register_workdir "$CHOSEN_WORKDIR"
 
-STATE_PROJECTS_DIR="$SCRIPT_DIR/claude-sandbox-persistent-state-${CHOSEN_AREA}/.claude/projects"
+STATE_PROJECTS_DIR="$SCRIPT_DIR/persistent-states/${CHOSEN_AREA}/.claude/projects"
 
 LAUNCH_ARGS=(--dangerously-skip-permissions)
 if [ "$CHOSEN_SESSION" != "NEW" ]; then

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -4,7 +4,7 @@ Default `CLAUDE_SANDBOX_PROJECTS_DIR` for the example env file. Mounted at
 `/workspace` inside the sandbox.
 
 Drop project trees in here, or override `CLAUDE_SANDBOX_PROJECTS_DIR` in your
-own `env.<INSTANCE>.sh` to point somewhere else on the host.
+own `envs/env.<INSTANCE>.sh` to point somewhere else on the host.
 
 This README is the only file tracked in git; everything else under
 `workspace/` is ignored.


### PR DESCRIPTION

## Summary

Restructures the repo so each workspace has one env script with its own persistent state, both grouped into dedicated folders. Shared settings (`claude-sandbox-shared/`) are unchanged.

**Layout change:**
| Before (repo root) | After |
|---|---|
| `env.<NAME>.sh` | `envs/env.<NAME>.sh` |
| `claude-sandbox-persistent-state-<INSTANCE>/` | `persistent-states/<INSTANCE>/` |

The state subdir also drops the long `claude-sandbox-persistent-state-` prefix — it's now just the instance name. The mapping is 1:1: one `envs/env.<NAME>.sh` → one instance → one
`persistent-states/<INSTANCE>/`.

New workflow: `source envs/env.<NAME>.sh && ./run_claude_docker.sh` (or `./start_sandbox.sh`).

## Changes

**Moves** (env files + state dirs are gitignored; only `env.example.sh` and a state README are tracked):
- `git mv env.example.sh → envs/env.example.sh`; the other env files moved on disk.
- All state dirs moved into `persistent-states/<INSTANCE>/` with the prefix stripped. Session data preserved.

**Code:**
- `run_claude_docker.sh` — `PERSISTENT_STATE_DIR → persistent-states/${CLAUDE_SANDBOX_INSTANCE}`; help text → `envs/`. (Container name + DinD volume still keyed on `INSTANCE_SUFFIX` —
unchanged.)
- `envs/*.sh` — `__ENV_SCRIPT_DIR` resolves to the **parent** of the file's dir (envs/ is one level below repo root), so `${__ENV_SCRIPT_DIR}` defaults and `sandbox_lib`'s substitution
still resolve against repo root.
- `scripts/sandbox_lib.sh` — workdir-collection glob → `envs/env.*.sh`.
- `start_sandbox.sh` — env glob, state_dir, session-project paths, managed-block writeback target, and display strings → new layout.
- `SESSION_ARCHIVE/archive_sessions.sh` — live-state glob → `persistent-states/*`.

**Docs:** README, `SESSION_ARCHIVE/README.md`, `workspace/README.md`, `scripts/setup_host_macos.sh`, code comments → new paths. New `persistent-states/README.md`. Fixed a dangling "step 4"
heading in README (pre-existing typo).

**.gitignore:** `persistent-states/*` (keep README), `envs/env.*.sh` (keep example). Legacy root-level rules kept so old clones stay clean. Also restored a missing `docker/hf-cache/` ignore
(155 MB model-cache footgun) that had dropped off this branch.

## Verification

- Every env sources with repo-root resolution intact.
- `run_claude_docker.sh` computes `persistent-states/main`; `start_sandbox.sh` discovers all envs; `sandbox_lib` collects workdirs; `archive_sessions.sh` sees the moved dirs.
- All scripts pass `bash -n`.
- Full post-refactor audit (README, CLAUDE.md, all launchers/helpers/hooks) found no remaining stale path or conceptual references to the old layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)