### PR TITLE
fix(setup): unblock new-machine setup_host_linux.sh

### DIFF
--- a/scripts/setup_host_linux.sh
+++ b/scripts/setup_host_linux.sh
@@ -57,7 +57,11 @@ if [[ -z "${DOCKER_PIN_VERSION}" || -z "${DOCKER_CLI_PIN_VERSION}" ]]; then
 fi
 
 echo "Pinning docker-ce to ${DOCKER_PIN_VERSION} (Docker 29.x breaks sysbox-runc)."
-sudo apt install -y \
+# --allow-downgrades: we deliberately pin BELOW the latest docker-ce (29.x
+# breaks sysbox-runc). On a machine that already has a newer docker-ce,
+# apt refuses to move to the older pin under -y without this flag
+# ("Packages were downgraded and -y was used without --allow-downgrades").
+sudo apt install -y --allow-downgrades \
   "docker-ce=${DOCKER_PIN_VERSION}" \
   "docker-ce-cli=${DOCKER_CLI_PIN_VERSION}" \
   containerd.io docker-buildx-plugin docker-compose-plugin
@@ -72,7 +76,10 @@ sudo usermod -aG docker $USER
 
 echo "Installing sysbox for docker-in-a-docker support"
 wget https://downloads.nestybox.com/sysbox/releases/v0.6.7/sysbox-ce_0.6.7-0.linux_amd64.deb
-sudo apt install -y ./sysbox-ce_0.6.7-0.linux_amd64.deb
+# --allow-downgrades for the same reason as docker above: sysbox is version-
+# pinned, so a machine with a newer sysbox-ce already installed would need
+# apt's permission to move to this pinned build under -y.
+sudo apt install -y --allow-downgrades ./sysbox-ce_0.6.7-0.linux_amd64.deb
 # postinst restarts dockerd, registers sysbox-runc in /etc/docker/daemon.json
 
 #Verify:

--- a/scripts/setup_host_linux.sh
+++ b/scripts/setup_host_linux.sh
@@ -135,7 +135,10 @@ echo "Ensuring python3 + python3-venv + python3-pip are installed"
 sudo apt-get install -y --no-install-recommends python3 python3-venv python3-pip
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-bash "${SCRIPT_DIR}/host_fiss_mcp/install.sh"
+# host_fiss_mcp/ lives at the REPO ROOT, not under scripts/. SCRIPT_DIR here
+# is the scripts/ dir (this file's location), so go up one level.
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+bash "${REPO_ROOT}/host_fiss_mcp/install.sh"
 
 ################################################################################
 


### PR DESCRIPTION
Two bugs that stopped `./setup_host.sh` from completing on a fresh Linux machine. Both in `scripts/setup_host_linux.sh`.

## 1. apt refuses the deliberate docker/sysbox downgrade

E: Packages were downgraded and -y was used without --allow-downgrades

The script deliberately pins `docker-ce` **below** the latest (29.x breaks sysbox-runc) and installs a version-pinned sysbox `.deb`. On a machine that already has a newer `docker-ce` or
`sysbox-ce` (e.g. fresh install pulled 29.7.2), apt won't move to the older pin under `-y` without `--allow-downgrades`.

Added `--allow-downgrades` to both pinned installs (the `docker-ce`/`-cli` line and the sysbox `.deb`). Latest-version installs (git, curl, postfix, python) are untouched — they can't
downgrade.

## 2. wrong path to the fiss-mcp installer

bash: .../scripts/host_fiss_mcp/install.sh: No such file or directory

The script invoked `${SCRIPT_DIR}/host_fiss_mcp/install.sh`, but `SCRIPT_DIR` is the `scripts/` dir while `host_fiss_mcp/` lives at the **repo root**. Derived `REPO_ROOT` (parent of
`scripts/`) and invoke `${REPO_ROOT}/host_fiss_mcp/install.sh` — matching what `setup_host_macos.sh` already does.

## Testing

`bash -n` clean. Path fix verified against the real tree (`host_fiss_mcp/install.sh` exists at repo root). The `--allow-downgrades` fix reproduced against a machine with `docker-ce 29.7.2`
installed vs the 28.x pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)