### PR TITLE
sandbox: auto-name sessions + default --dangerously-skip-permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,16 @@ The launcher script (`run_claude_docker.sh`) forwards any arguments to `claude` 
 ./run_claude_docker.sh                                     # fresh session
 ./run_claude_docker.sh --continue                          # resume most recent
 ./run_claude_docker.sh --resume <session-id>               # resume specific
-./run_claude_docker.sh --dangerously-skip-permissions      # no prompts
-./run_claude_docker.sh --continue --dangerously-skip-permissions
 ```
 
-To drop into a shell instead of `claude`, change the trailing `claude "$@"` in `run_claude_docker.sh` to `/bin/bash`.
+### Sandbox defaults applied at launch
+
+`docker/start_script.sh` adds two flags to the `claude` invocation automatically, each only if you didn't pass it yourself (an explicit flag always wins):
+
+- **`--name "$CLAUDE_SANDBOX_INSTANCE"`** — the session is auto-named after the instance from your env script, so sessions are identifiable in the picker and Remote Control without typing `-n` every launch. Pass your own `--name`/`-n` to override.
+- **`--dangerously-skip-permissions`** — this is a disposable, filesystem-isolated sandbox built for unattended work, so permission prompts are skipped by default; you no longer type the flag every time. This means the agent runs tool calls inside the container **without prompting** — appropriate here because the container can only see the mounted workspace and its own state, never the host. If you want prompts back for a session, edit the `claude` invocation at the bottom of `docker/start_script.sh` (remove the auto-added flag).
+
+To drop into a shell instead of `claude`, change the trailing `exec claude ...` in `docker/start_script.sh` to `/bin/bash`.
 
 ## Headroom proxy (token compression)
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ The launcher script (`run_claude_docker.sh`) forwards any arguments to `claude` 
 
 ### Sandbox defaults applied at launch
 
-`docker/start_script.sh` adds two flags to the `claude` invocation automatically, each only if you didn't pass it yourself (an explicit flag always wins):
+`run_claude_docker.sh` injects two flags into the args that reach `claude` in the container, each only if you didn't pass it yourself (an explicit flag always wins). This is done **host-side in the launcher**, not in the baked image, so changing these defaults needs no `make build`:
 
 - **`--name "$CLAUDE_SANDBOX_INSTANCE"`** — the session is auto-named after the instance from your env script, so sessions are identifiable in the picker and Remote Control without typing `-n` every launch. Pass your own `--name`/`-n` to override.
-- **`--dangerously-skip-permissions`** — this is a disposable, filesystem-isolated sandbox built for unattended work, so permission prompts are skipped by default; you no longer type the flag every time. This means the agent runs tool calls inside the container **without prompting** — appropriate here because the container can only see the mounted workspace and its own state, never the host. If you want prompts back for a session, edit the `claude` invocation at the bottom of `docker/start_script.sh` (remove the auto-added flag).
+- **`--dangerously-skip-permissions`** — this is a disposable, filesystem-isolated sandbox built for unattended work, so permission prompts are skipped by default; you no longer type the flag every time. The agent runs tool calls inside the container **without prompting** — appropriate here because the container only sees the mounted workspace and its own state, never the host. To get prompts back, edit the `CLAUDE_DEFAULT_ARGS` block near the bottom of `run_claude_docker.sh`.
 
-To drop into a shell instead of `claude`, change the trailing `exec claude ...` in `docker/start_script.sh` to `/bin/bash`.
+To drop into a shell instead of `claude`, change the trailing `claude "$@"` in `docker/start_script.sh` to `/bin/bash`.
 
 ## Headroom proxy (token compression)
 

--- a/docker/start_script.sh
+++ b/docker/start_script.sh
@@ -207,25 +207,7 @@ check_pin() {
 check_pin caveman 63a91ecadbf4c4719a4602a5abb00883f9966034
 check_pin ponytail bc9ee949d5f439e8b9f3bb92c6d6d3d1e6ebd324
 
-# Run claude. Build the arg list with two sandbox defaults, each added only
-# if the caller didn't already supply it (so an explicit flag in "$@" wins):
-#
-#   --name <CLAUDE_SANDBOX_INSTANCE>   auto-name the session after the
-#       instance (from the env script), so sessions are identifiable in the
-#       picker / Remote Control without typing -n every launch.
-#   --dangerously-skip-permissions     this is a disposable, filesystem-
-#       isolated sandbox whose whole point is unattended work; the operator
-#       shouldn't have to type the flag every time. See CLAUDE.md.
-CLAUDE_ARGS=()
-
-case " $* " in
-  *" --name "*|*" -n "*) : ;;   # caller set a name; don't override
-  *) [[ -n "${CLAUDE_SANDBOX_INSTANCE:-}" ]] && CLAUDE_ARGS+=(--name "${CLAUDE_SANDBOX_INSTANCE}") ;;
-esac
-
-case " $* " in
-  *" --dangerously-skip-permissions "*) : ;;   # already set by caller
-  *) CLAUDE_ARGS+=(--dangerously-skip-permissions) ;;
-esac
-
-exec claude "${CLAUDE_ARGS[@]}" "$@"
+# Run claude. Sandbox launch defaults (--name, --dangerously-skip-permissions)
+# are injected host-side by run_claude_docker.sh and arrive in "$@", so this
+# stays a plain passthrough — no rebuild needed to change those defaults.
+claude "$@"

--- a/docker/start_script.sh
+++ b/docker/start_script.sh
@@ -207,5 +207,25 @@ check_pin() {
 check_pin caveman 63a91ecadbf4c4719a4602a5abb00883f9966034
 check_pin ponytail bc9ee949d5f439e8b9f3bb92c6d6d3d1e6ebd324
 
-# Run claude:
-claude "$@"
+# Run claude. Build the arg list with two sandbox defaults, each added only
+# if the caller didn't already supply it (so an explicit flag in "$@" wins):
+#
+#   --name <CLAUDE_SANDBOX_INSTANCE>   auto-name the session after the
+#       instance (from the env script), so sessions are identifiable in the
+#       picker / Remote Control without typing -n every launch.
+#   --dangerously-skip-permissions     this is a disposable, filesystem-
+#       isolated sandbox whose whole point is unattended work; the operator
+#       shouldn't have to type the flag every time. See CLAUDE.md.
+CLAUDE_ARGS=()
+
+case " $* " in
+  *" --name "*|*" -n "*) : ;;   # caller set a name; don't override
+  *) [[ -n "${CLAUDE_SANDBOX_INSTANCE:-}" ]] && CLAUDE_ARGS+=(--name "${CLAUDE_SANDBOX_INSTANCE}") ;;
+esac
+
+case " $* " in
+  *" --dangerously-skip-permissions "*) : ;;   # already set by caller
+  *) CLAUDE_ARGS+=(--dangerously-skip-permissions) ;;
+esac
+
+exec claude "${CLAUDE_ARGS[@]}" "$@"

--- a/run_claude_docker.sh
+++ b/run_claude_docker.sh
@@ -774,6 +774,7 @@ docker run --rm -it \
   ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
   -e HOST_UID="$(id -u)" \
   -e HOST_GID="$(id -g)" \
+  -e CLAUDE_SANDBOX_INSTANCE="${CLAUDE_SANDBOX_INSTANCE}" \
   -e HEADROOM="${HEADROOM:-0}" \
   -e HEADROOM_PORT="${HEADROOM_PORT:-8787}" \
   -e CLAUDE_NOTIFY_EMAIL="${CLAUDE_NOTIFY_EMAIL:-}" \

--- a/run_claude_docker.sh
+++ b/run_claude_docker.sh
@@ -755,6 +755,25 @@ else
   fi
 fi
 
+# Sandbox launch defaults, injected into the args that reach `claude` inside
+# the container. Done HOST-SIDE (here) rather than in the baked start_script
+# so changing them needs no image rebuild. Each is added only if the caller
+# didn't already pass it, so an explicit flag wins.
+#
+#   --name <CLAUDE_SANDBOX_INSTANCE>  auto-name the session after the instance
+#       so sessions are identifiable without typing -n every launch.
+#   --dangerously-skip-permissions   disposable, host-isolated sandbox built
+#       for unattended work — don't make the operator type this every time.
+CLAUDE_DEFAULT_ARGS=()
+case " $* " in
+  *" --name "*|*" -n "*) : ;;
+  *) [[ -n "${CLAUDE_SANDBOX_INSTANCE:-}" ]] && CLAUDE_DEFAULT_ARGS+=(--name "${CLAUDE_SANDBOX_INSTANCE}") ;;
+esac
+case " $* " in
+  *" --dangerously-skip-permissions "*) : ;;
+  *) CLAUDE_DEFAULT_ARGS+=(--dangerously-skip-permissions) ;;
+esac
+
 # Make it so. Any args ($@) are passed to `claude` inside the container —
 # e.g. --resume <id>, --continue, --dangerously-skip-permissions.
 # To drop into a shell instead, swap `claude "$@"` below for `/bin/bash`.
@@ -774,7 +793,6 @@ docker run --rm -it \
   ${GPU_FLAGS[@]+"${GPU_FLAGS[@]}"} \
   -e HOST_UID="$(id -u)" \
   -e HOST_GID="$(id -g)" \
-  -e CLAUDE_SANDBOX_INSTANCE="${CLAUDE_SANDBOX_INSTANCE}" \
   -e HEADROOM="${HEADROOM:-0}" \
   -e HEADROOM_PORT="${HEADROOM_PORT:-8787}" \
   -e CLAUDE_NOTIFY_EMAIL="${CLAUDE_NOTIFY_EMAIL:-}" \
@@ -792,5 +810,6 @@ docker run --rm -it \
   -e CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-}" \
   -e ANTHROPIC_TARGET_API_URL="${VERTEX_PROXY_URL_FOR_CONTAINER}" \
   -w /workspace \
-  claude-sandbox:${DOCKER_IMAGE_VERSION} /home/claude/start_script.sh "$@"
+  claude-sandbox:${DOCKER_IMAGE_VERSION} /home/claude/start_script.sh \
+    ${CLAUDE_DEFAULT_ARGS[@]+"${CLAUDE_DEFAULT_ARGS[@]}"} "$@"
 


### PR DESCRIPTION
Two launch conveniences, injected **host-side** in `run_claude_docker.sh` so they take effect with no image rebuild. Each is added to the `claude` args only if you didn't pass it yourself —
an explicit flag always wins.

## Changes

- **Auto-name the session** — `--name "$CLAUDE_SANDBOX_INSTANCE"`. The session is named after the instance from your env script, so sessions are identifiable in the picker and Remote
Control without typing `-n` every launch. Pass your own `--name`/`-n` to override.
- **Default `--dangerously-skip-permissions`** — no more typing it every launch. The agent runs tool calls inside the container without prompting, which is appropriate here: the container
only sees the mounted workspace and its own state, never the host. Opt back into prompts by editing the `CLAUDE_DEFAULT_ARGS` block in `run_claude_docker.sh`.

## Implementation

- `run_claude_docker.sh` builds `CLAUDE_DEFAULT_ARGS` with case-glob dedup guards and passes it ahead of `"$@"` to the container's `start_script.sh`.
- `docker/start_script.sh` stays a plain `claude "$@"` passthrough — behaviorally identical to the shipped image, so **no `make build` required**.
- README gains a "Sandbox defaults applied at launch" subsection; a stale pointer (claude invocation location) is corrected.

## Why host-side

An earlier cut injected these in `docker/start_script.sh`, but that's baked into the image and would need a rebuild to change. Moving the logic to the launcher makes the defaults editable
without rebuilding.

## Testing

Simulated the arg-building across five cases — default, `--resume`, explicit `--name`, explicit skip-flag, empty instance — each produces the right `claude` command with no duplication.
`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)