### PR TITLE
chore: bump headroom 0.24.0 -> 0.37.0 + switch to kompress-v2-base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN python3 -m venv /opt/claude-venv && \
     /opt/claude-venv/bin/pip install --no-cache-dir \
       numpy pandas matplotlib scipy scikit-learn seaborn \
       ipython jupyter requests \
-      "headroom-ai[proxy]==0.24.0" && \
+      "headroom-ai[proxy]==0.37.0" && \
     chown -R claude:claude /opt/claude-venv
 
 # fiss-mcp lives on the HOST, not in the container. The launcher

--- a/run_claude_docker.sh
+++ b/run_claude_docker.sh
@@ -102,9 +102,11 @@ SCRIPT_DIR=$(__resolve_dir)
 # ~/.cache/huggingface — the model is identical across instances/projects,
 # so it's downloaded once ever and shared by all. Gitignored.
 HF_CACHE_DIR="${SCRIPT_DIR}/hf-cache-runtime"
-# The model headroom 0.24.0 pulls. Update if the pinned headroom version
-# changes the model it loads.
-HEADROOM_MODEL_REPO="chopratejas/kompress-base"
+# The model headroom pulls (kompress-v2-base since headroom 0.25 —
+# headroom 0.24 used kompress-base). Keep this in sync with the
+# headroom-ai pin in docker/Dockerfile; if a future headroom changes its
+# default model, update this repo id.
+HEADROOM_MODEL_REPO="chopratejas/kompress-v2-base"
 
 # Ensure headroom's model is present in the shared host cache. Idempotent:
 # returns immediately if already cached; otherwise downloads it once via a
@@ -126,14 +128,19 @@ ensure_headroom_model() {
   # huggingface_hub picks up HF_TOKEN automatically. Empty -> anonymous.
   local hf_auth=() authnote="anonymous"
   if [[ -n "${HF_TOKEN:-}" ]]; then hf_auth=(-e HF_TOKEN); authnote="authenticated"; fi
-  echo "headroom-model: downloading ${HEADROOM_MODEL_REPO} into ${HF_CACHE_DIR#$SCRIPT_DIR/} (one-time, ~150MB, ${authnote})..."
+  # allow_patterns: pull ONLY what headroom's default runtime loads — the
+  # weight-only int8 ONNX + tokenizer + small configs (~280MB) — not the
+  # full ~1.5GB repo (it also ships a 600MB fp32 ONNX, a 315MB safetensors,
+  # and a 302MB merged.pt for training / non-default backends we don't use).
+  # If a future headroom defaults to a different checkpoint, widen this.
+  echo "headroom-model: downloading ${HEADROOM_MODEL_REPO} into ${HF_CACHE_DIR#$SCRIPT_DIR/} (one-time, ~280MB, ${authnote})..."
   if docker run --rm \
        -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
        "${hf_auth[@]+"${hf_auth[@]}"}" \
        -v "${HF_CACHE_DIR}:/home/claude/.cache/huggingface" \
        "claude-sandbox:${DOCKER_IMAGE_VERSION}" \
        /opt/claude-venv/bin/python -c \
-       "from huggingface_hub import snapshot_download as s; s('${HEADROOM_MODEL_REPO}')"; then
+       "from huggingface_hub import snapshot_download as s; s('${HEADROOM_MODEL_REPO}', allow_patterns=['onnx/kompress-int8*','tokenizer*','*.json','adapter/**'])"; then
     echo "headroom-model: done."
   else
     echo "headroom-model: WARNING — prefetch failed; headroom will download at" >&2


### PR DESCRIPTION
13 releases of upstream work. Highlights for this repo:
- The 1M-context cap we'd flagged is fixed upstream: 0.28 added --1m, 0.36 "honor the [1m] 1M-context tier and price it correctly" — so opus[1m] keeps its 1M window through the proxy (0.24 silently dropped it to 200k).
- Security: 0.37 closes a Vertex path-parameter SSRF (#3304) and enforces a token on WebSocket handshakes — relevant to our Vertex mode.
- Better compression/cache, Rust-ported kompress, subagent-output fix.

Model change (the important bit): headroom switched its default kompress model from kompress-base to kompress-v2-base at 0.25. Updated HEADROOM_MODEL_REPO to chopratejas/kompress-v2-base so the prefetch pulls the right model. v2-base is a ~1.5GB repo (fp32 onnx + safetensors + merged.pt + int8 onnx); headroom's default runtime uses the weight-only int8 ONNX, so the prefetch now uses allow_patterns to fetch just that + tokenizer + configs + adapter (~269MB) instead of the whole repo.

Verified without a full image rebuild by installing headroom 0.37 in a throwaway venv and running it: it starts with our `--no-telemetry --port` flags and downloads models--chopratejas--kompress-v2-base; the allow_patterns snapshot_download fetches the int8 onnx + tokenizer + configs + adapter (269MB, confirmed file list). Needs `make build` on the host to take effect (headroom is baked into the image); end-to-end launch is the operator's final check.